### PR TITLE
feat: include OP token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants-v2",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants-v2.git",
   "author": "hello@umaproject.org",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -217,4 +217,12 @@ export const TOKEN_SYMBOLS_MAP = {
       [CHAIN_IDs.MUMBAI]: "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889",
     },
   },
+  OP: {
+    name: "Optimism",
+    symbol: "OP",
+    decimals: 18,
+    addresses: {
+      [CHAIN_IDs.OPTIMISM]: "0x4200000000000000000000000000000000000042",
+    },
+  },
 };


### PR DESCRIPTION
This PR adds the optimism governance token to the `TOKEN_SYMBOLS` constants.