### PR TITLE
fix: Revert wECO mainnet to a dummy address

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -230,7 +230,7 @@ export const TOKEN_SYMBOLS_MAP = {
     symbol: "wECO",
     decimals: 18,
     addresses: {
-      [CHAIN_IDs.MAINNET]: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // dummy - not deployed yet. Using WETH for now.
+      [CHAIN_IDs.MAINNET]: "0xaa55aa55aa55aa55aa55aa55aa55aa55aa55aa55", // dummy - not deployed yet.
       [CHAIN_IDs.GOERLI]: "0x495A1619EEAcD776Eaa241df7A38dC74Ee7F1779",
       [CHAIN_IDs.OPTIMISM_GOERLI]: "0x130c1Dcc9FD997Fa02f555dad54EDaf553f2555A",
       [CHAIN_IDs.BASE_GOERLI]: "0x4489d0a0345eCB216A3994De780d453c7fA6312C",


### PR DESCRIPTION
There are utility functions that iterate over the array of TOKEN_SYMBOLS_MAP values and return the first symbol matching an address for a particular chain ID. If chainIds are reused in this way, the ordering of TOKEN_SYMBOLS_MAP determines which symbol would be returned. This is generally undesirable, so avoid reusing token addresses in this way.